### PR TITLE
Features/separate permissions

### DIFF
--- a/project/config/permissions.py
+++ b/project/config/permissions.py
@@ -1,7 +1,8 @@
-from rest_framework import permissions
+from rest_framework.permissions import BasePermission
+from core.ERROR.error_cases import GlobalErrorMessage401
 
 
-class MyIsAuthenticated(permissions.BasePermission):
+class MyIsAuthenticated(BasePermission):
     message = ''
 
     def has_permission(self, request, view):
@@ -17,4 +18,11 @@ class MyIsAuthenticated(permissions.BasePermission):
             self.message = '로그인이 필요합니다.'
             return False
 
+        return True
+
+
+class IsOwnedByProfile(BasePermission):
+    def has_object_permission(self, request, view, obj):
+        if not (obj.profile.pk == request.user.pk):
+            raise GlobalErrorMessage401(str("다른 사람의 일기는 볼 수 없어요."))
         return True

--- a/project/core/ERROR/error_cases.py
+++ b/project/core/ERROR/error_cases.py
@@ -32,3 +32,15 @@ class GlobalErrorMessage400(Exception):
         })
     """
     pass
+
+
+class GlobalErrorMessage401(Exception):
+    """
+        아래와 같은 형태로 사용이 되며,
+        단지, message 만 같이 보내기 위해서 사용한다.
+        return Response({
+            'response': 'error',
+            'message': "이게 되지 않습니다."
+        })
+    """
+    pass

--- a/project/core/ERROR/error_handler.py
+++ b/project/core/ERROR/error_handler.py
@@ -37,3 +37,9 @@ def custom_exception_handler(exc, context):
             'response': 'error',
             'message': str(exc)
         }, status=status.HTTP_400_BAD_REQUEST)
+
+    if isinstance(exc, GlobalErrorMessage401):
+        return Response({
+            'response': 'error',
+            'message': str(exc)
+        }, status=status.HTTP_401_UNAUTHORIZED)

--- a/project/record/API/post.py
+++ b/project/record/API/post.py
@@ -101,6 +101,7 @@ class PostView(APIView):
         data._mutable = True
         data['profile'] = email
         data['question'] = get_question_of_user_question(profile_pk=profile.pk)
+        request.data["image"].name = fix_image_name(image_name=request.data["image"].name)
 
         # 연속 기록 체크
         today = date.today()


### PR DESCRIPTION
1. record/API/utils.py 의 fix_image_name()를 record/API/post.py의 PostView의 post()에 추가해줌
일기 등록 시 이미지 확장자 에러 해결!

2. post의 object level 단위 permission 추가
- GlobalError에 HTTP_401_UNAUTHORIZED case 추가
- config/permissions.py에 IsOwnedByProfile 추가
- record/API/post.py에 get_post_object() --> get_object()