### PR TITLE
Fix login Error

### DIFF
--- a/project/core/API/jorang.py
+++ b/project/core/API/jorang.py
@@ -106,7 +106,8 @@ def upgrade_jorang_status(profile):
 
 def downgrade_jorang_status(profile):
     if profile.post.last() is None:
-        raise GlobalErrorMessage("유저에게 작성된 일기가 없습니다!!")
+        return 
+        # raise GlobalErrorMessage("유저에게 작성된 일기가 없습니다!!")
 
     last_post_date = profile.post.last().created_at
     timedelta_last_post_and_today = date.today() - last_post_date


### PR DESCRIPTION
<img width="494" alt="KakaoTalk_Photo_2020-11-12-14-52-03" src="https://user-images.githubusercontent.com/41981538/98901176-a7c21000-24f6-11eb-885a-aa9dc989947f.png">

```python
def downgrade_jorang_status(profile):
    if profile.post.last() is None:
        raise GlobalErrorMessage("유저에게 작성된 일기가 없습니다!!")
```
위 부분에서 로그인이 안되는 문제가 발생하여, 수정을 함